### PR TITLE
added overall themeprovider; added signin/signup page

### DIFF
--- a/bubble-tea/package.json
+++ b/bubble-tea/package.json
@@ -3,12 +3,20 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@emotion/react": "^11.10.5",
+    "@emotion/styled": "^11.10.5",
+    "@fontsource/roboto": "^4.5.8",
+    "@mui/icons-material": "^5.10.14",
+    "@mui/lab": "^5.0.0-alpha.108",
+    "@mui/material": "^5.10.14",
+    "@mui/styled-engine-sc": "^5.10.14",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
+    "styled-components": "^5.3.6",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/bubble-tea/src/App.css
+++ b/bubble-tea/src/App.css
@@ -14,7 +14,7 @@
 }
 
 .App-header {
-  background-color: #282c34;
+  background-color: #efeff0;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -35,4 +35,8 @@
   to {
     transform: rotate(360deg);
   }
+}
+
+.TabName {
+  font-size: 1.5em;
 }

--- a/bubble-tea/src/App.js
+++ b/bubble-tea/src/App.js
@@ -1,24 +1,37 @@
-import logo from './logo.svg';
 import './App.css';
+import CssBaseline from '@mui/material/CssBaseline';
+import InputAdornments from './components/Authentication/InputAdornments';
+import AuthenticationPage from './components/Authentication/AuthenticationPage';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#7F669D',
+      contrastText: "#fff"
+    },
+    secondary: {
+      main: '#BA94D1',
+    },
+    Info: {
+      main: '#DEBACE',
+    },
+    Success: {
+      main: '#BCCEF8',
+    },
+    Warning: {
+      main: '#FBFACD',
+    },
+  },
+});
+
 
 function App() {
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+        <AuthenticationPage/>
+    </ThemeProvider>
   );
 }
 

--- a/bubble-tea/src/components/Authentication/AuthenticationPage.js
+++ b/bubble-tea/src/components/Authentication/AuthenticationPage.js
@@ -1,0 +1,66 @@
+import * as React from 'react';
+
+import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import SignIn from './SignIn';
+import SignUp from './SignUp';
+import Tab from '@mui/material/Tab';
+import TabContext from '@mui/lab/TabContext';
+import TabList from '@mui/lab/TabList';
+import TabPanel from '@mui/lab/TabPanel';
+import { useTheme } from '@mui/material/styles';
+
+
+export default function AuthenticationPage() {
+  const [value, setValue] = React.useState('SignIn');
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    console.log({
+      email: data.get('email'),
+      password: data.get('password'),
+    });
+  };
+
+  const theme = useTheme();
+  const handleTabChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+
+  return (
+
+      <Grid container component="main" sx={{ height: '100vh' }}>
+        <Grid
+          item
+          xs={false}
+          sm={4}
+          md={6}
+          sx={{
+            backgroundImage: 'url(https://source.unsplash.com/random)',
+            backgroundRepeat: 'no-repeat',
+            backgroundColor: (t) =>
+              t.palette.mode === 'light' ? t.palette.grey[50] : t.palette.grey[900],
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+          }}
+        />
+        <Grid item xs={12} sm={8} md={6} component={Paper} elevation={5} square>
+        <TabContext value={value}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+            <TabList onChange={handleTabChange} aria-label="lab API tabs example" textColor="secondary" indicatorColor="secondary" centered>
+                  <Tab label={<span className="TabName" >Sign In</span>} value="SignIn"  />
+                  <Tab label={<span className="TabName" >Sign Up</span>} value="SignUp"  />
+            </TabList>
+          </Box>
+          <TabPanel value="SignIn"> <SignIn/> </TabPanel>
+          <TabPanel value="SignUp"> <SignUp/> </TabPanel>
+        </TabContext>
+
+
+        </Grid>
+      </Grid>
+  );
+}

--- a/bubble-tea/src/components/Authentication/InputAdornments.js
+++ b/bubble-tea/src/components/Authentication/InputAdornments.js
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import OutlinedInput from '@mui/material/OutlinedInput';
+import InputLabel from '@mui/material/InputLabel';
+import InputAdornment from '@mui/material/InputAdornment';
+import FormControl from '@mui/material/FormControl';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import { purple } from '@mui/material/colors';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
+export default function InputAdornments() {
+  const [values, setValues] = React.useState({
+    password: '',
+    username: '',
+    email: '',
+    showPassword: false,
+    agreeToTerms: false,
+  });
+
+  const handleChange =
+    (prop) => (event) => {
+      setValues({ ...values, [prop]: event.target.value });
+    };
+
+  const handleClickShowPassword = () => {
+    setValues({
+      ...values,
+      showPassword: !values.showPassword,
+    });
+  };
+
+  const handleMouseDownPassword = (event) => {
+    event.preventDefault();
+  };
+
+  return (
+    <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
+      <div>
+      <FormControl sx={{ m: 1, width: '25ch' }} variant="outlined">
+          <InputLabel htmlFor="outlined-adornment-username">Username *</InputLabel>
+          <OutlinedInput
+            id="outlined-adornment-email"
+            value={values.username}
+            onChange={handleChange('username')}
+            label="Username"
+          />
+
+        </FormControl>
+      <div>
+      <FormControl sx={{ m: 1, width: '25ch' }} variant="outlined">
+          <InputLabel htmlFor="outlined-adornment-email">Email *</InputLabel>
+          <OutlinedInput
+            id="outlined-adornment-email"
+            value={values.email}
+            onChange={handleChange('email')}
+            label="Email"
+          />
+
+        </FormControl>
+        <div>
+        <FormControl sx={{ m: 1, width: '25ch' }} variant="outlined">
+          <InputLabel htmlFor="outlined-adornment-password">Password *</InputLabel>
+          <OutlinedInput
+            id="outlined-adornment-password"
+            type={values.showPassword ? 'text' : 'password'}
+            value={values.password}
+            onChange={handleChange('password')}
+            endAdornment={
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="toggle password visibility"
+                  onClick={handleClickShowPassword}
+                  onMouseDown={handleMouseDownPassword}
+                  edge="end"
+                >
+                  {values.showPassword ? <VisibilityOff /> : <Visibility />}
+                </IconButton>
+              </InputAdornment>
+            }
+            label="Password"
+          />
+            <Checkbox
+            sx={{
+              color: purple[600],
+              '&.Mui-checked': {
+                color: purple[200],
+              },
+            }}
+            checked={values.agreeToTerms}
+          />
+        </FormControl>
+        </div>
+          </div>
+        </div>
+
+
+
+    </Box>
+  );
+}

--- a/bubble-tea/src/components/Authentication/SignIn.js
+++ b/bubble-tea/src/components/Authentication/SignIn.js
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import Avatar from '@mui/material/Avatar';
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import Link from '@mui/material/Link';
+import Grid from '@mui/material/Grid';
+import Box from '@mui/material/Box';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import { useTheme } from '@mui/material/styles';
+
+function Copyright(props) {
+  return (
+    <Typography variant="body2" color="text.secondary" align="center" {...props}>
+      {'Copyright © '}
+      <Link color="inherit" >
+        Starducks
+      </Link>{' '}
+      {new Date().getFullYear()}
+      {'.'}
+    </Typography>
+  );
+}
+
+
+
+
+export default function SignIn() {
+  const theme = useTheme();
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    console.log({
+      email: data.get('email'),
+      password: data.get('password'),
+    });
+  };
+
+  return (
+      <Container component="main" maxWidth="xs">
+        <Box
+          sx={{
+            my: 8,
+            mx: 4,
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+
+          <Avatar sx={{ m: 1, bgcolor: `${theme.palette.secondary.main}` }}>
+            <LockOutlinedIcon />
+          </Avatar>
+          <Typography component="h1" variant="h5">
+            Sign in
+          </Typography>
+          <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              id="email"
+              label="Email Address"
+              name="email"
+              autoComplete="email"
+              autoFocus
+            />
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              name="password"
+              label="Password"
+              type="password"
+              id="password"
+              autoComplete="current-password"
+            />
+            <FormControlLabel
+              control={<Checkbox value="remember" color="primary" />}
+              label="Remember me"
+            />
+            <Button
+              type="submit"
+              fullWidth
+              variant="contained"
+              sx={{ mt: 3, mb: 2 }}
+            >
+              Sign In
+            </Button>
+            <Grid container>
+              <Grid item xs>
+                <Link href="#" variant="body2">
+                  Forgot password?
+                </Link>
+              </Grid>
+            </Grid>
+          </Box>
+        </Box>
+        <Copyright sx={{ mt: 8, mb: 4 }} />
+      </Container>
+  );
+}

--- a/bubble-tea/src/components/Authentication/SignUp.js
+++ b/bubble-tea/src/components/Authentication/SignUp.js
@@ -1,0 +1,124 @@
+import * as React from "react";
+import Avatar from "@mui/material/Avatar";
+import Button from "@mui/material/Button";
+import CssBaseline from "@mui/material/CssBaseline";
+import TextField from "@mui/material/TextField";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Checkbox from "@mui/material/Checkbox";
+import Link from "@mui/material/Link";
+import Grid from "@mui/material/Grid";
+import Box from "@mui/material/Box";
+import LockOutlinedIcon from "@mui/icons-material/LockOutlined";
+import Typography from "@mui/material/Typography";
+import Container from "@mui/material/Container";
+import { useTheme } from "@mui/material/styles";
+
+function Copyright(props) {
+	return (
+	<Typography
+	  variant="body2"
+	  color="text.secondary"
+	  align="center"
+	  {...props}
+	>
+	  {"Copyright © "}
+	  <Link color="inherit">Starducks</Link> {new Date().getFullYear()}
+	  {"."}
+	</Typography>
+  );
+}
+
+export default function SignUp() {
+  const theme = useTheme();
+  const handleSubmit = (event) => {
+	event.preventDefault();
+	const data = new FormData(event.currentTarget);
+	console.log({
+	  email: data.get("email"),
+	  password: data.get("password"),
+	});
+  };
+
+  return (
+	<Container component="main" maxWidth="xs">
+	  <Box
+		sx={{
+		  marginTop: 8,
+		  display: "flex",
+		  flexDirection: "column",
+		  alignItems: "center",
+		}}
+	  >
+		<Avatar sx={{ m: 1, bgcolor: "secondary.main" }}>
+		  <LockOutlinedIcon />
+		</Avatar>
+		<Typography component="h1" variant="h5">
+		  Sign up
+		</Typography>
+		<Box component="form" noValidate onSubmit={handleSubmit} sx={{ mt: 3 }}>
+		  <Grid container spacing={2}>
+			<Grid item xs={12} sm={6}>
+			  <TextField
+				autoComplete="given-name"
+				name="firstName"
+				required
+				fullWidth
+				id="firstName"
+				label="First Name"
+				autoFocus
+			  />
+			</Grid>
+			<Grid item xs={12} sm={6}>
+			  <TextField
+				required
+				fullWidth
+				id="lastName"
+				label="Last Name"
+				name="lastName"
+				autoComplete="family-name"
+			  />
+			</Grid>
+			<Grid item xs={12}>
+			  <TextField
+				required
+				fullWidth
+				id="email"
+				label="Email Address"
+				name="email"
+				autoComplete="email"
+			  />
+			</Grid>
+			<Grid item xs={12}>
+			  <TextField
+				required
+				fullWidth
+				name="password"
+				label="Password"
+				type="password"
+				id="password"
+				autoComplete="new-password"
+			  />
+			</Grid>
+			<Grid item xs={12}>
+			  <FormControlLabel
+				control={<Checkbox value="agreeToTerms" color="primary" />}
+				label="I agree to the following: Privacy Policy Tims Rewards Terms and Conditions Terms of Service"
+			  />
+			</Grid>
+		  </Grid>
+		  <Button
+			type="submit"
+			fullWidth
+			variant="contained"
+			sx={{ mt: 3, mb: 2 }}
+		  >
+			Sign Up
+		  </Button>
+		  <Grid container justifyContent="flex-end">
+		  </Grid>
+		</Box>
+	  </Box>
+	  <Copyright sx={{ mt: 5 }} />
+	</Container>
+  );
+}


### PR DESCRIPTION
Got the theme provider setup for the app, do the following in any child component to access the available customized colors.
First import useTheme,
`import { useTheme } from '@mui/material/styles';`

Inside the function or class,
`const theme = useTheme();`

Default is primary, you can reset by adding "secondary.main"  inside any mui component.
eg
`<Avatar sx={{ m: 1, bgcolor: "secondary.main" }}>`